### PR TITLE
Remove contentId from query

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -202,7 +202,6 @@ exports.createPages = async ({ graphql, actions }, configOptions) => {
         allAgilitySitemapNode {
           nodes {
             name
-            contentID
             pageID
             path
             title


### PR DESCRIPTION
Running `gatsby develop` was showing an error when querying for the sitemap from Agility as it was missing the field `contentId`. I hit my Agility instance with the API directly and the response was missing `coontentId` as well. (the response was okay though!) Not sure if this is an error or not, but figured I bring it to your attention as removing this from the GraphQL query when creating pages was able to clear up this error that prevented me from building my project.

Let me know! Thanks.