### PR TITLE
Fix multi-language support

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -419,7 +419,7 @@ const createPagesInEachLanguage = async ({ syncClient, languages, channelsRefs, 
 			}
 
 			isHomePage = false; //clear flag, homepage created...
-			pagePath = resolvePagePath(pagePath, languageCode);
+			pagePath = resolvePagePath(pagePath, language, isMultiLanguage);
 			await createAgilityPage({ createPage, createRedirect, pagePath, sitemapNode, isHomePage, pageTemplate, languageCode, isPreview, debug });
 
 			//if this is a dynamic page item, create a redirect for preview i.e. `~/posts/posts-dynamic?ContentID=12
@@ -464,7 +464,7 @@ const resolveLanguageCodes = (languages) => {
 
 const resolvePagePath = (path, language, isMultiLanguage) => {
 	if (isMultiLanguage) {
-		return `/${language.path}${path}`;
+		return `${language.path}${path}`;
 	} else {
 		return `${path}`;
 	}


### PR DESCRIPTION
Note that if you have multi lang - it will expect you too have the prefixing '/' in the language.path config in gatsby.config.js :
the reason being that the config should allow you to set a default language.

For example :

languages: [{
            // The name of the language code
            name: "English",
            // The actual language code set in Agility CMS
            code: "en-us", 
            // The name to be used in the URL path that represents the current language
            path: "/"
          },
          {
            // The name of the language code
            name: "French",
            // The actual language code set in Agility CMS
            code: "fr", 
            // The name to be used in the URL path that represents the current language
            path: "/fr"     
          }]

Here it will create pages for en under '/' but for fr under '/fr'