### PR TITLE
chore: Update repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby-source-agilitycms"
+    "url": "https://github.com/agility/gatsby-source-agilitycms"
   },
   "dependencies": {
     "@agility/content-sync": "^0.1.24"


### PR DESCRIPTION
Noticed on our plugins page that the "source on GitHub" wasn't working as the URL to the repo was wrong